### PR TITLE
Make usage of the new stop methodology

### DIFF
--- a/logstash-input-exec.gemspec
+++ b/logstash-input-exec.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
 
   # Gem dependencies
   s.add_runtime_dependency "logstash-core", '>= 1.4.0', '< 2.0.0'
-
+  s.add_runtime_dependency 'stud', '~> 0.0.22'
   s.add_runtime_dependency 'logstash-codec-plain'
 
   s.add_development_dependency 'logstash-devutils'

--- a/spec/inputs/exec_spec.rb
+++ b/spec/inputs/exec_spec.rb
@@ -1,1 +1,25 @@
-require "logstash/devutils/rspec/spec_helper"
+# encoding: utf-8
+require_relative "../spec_helper"
+
+describe LogStash::Inputs::Exec do
+
+  it "should register" do
+    input = LogStash::Plugin.lookup("input", "exec").new("command" => "uptime", "interval" => 0)
+
+    # register will try to load jars and raise if it cannot find jars or if org.apache.log4j.spi.LoggingEvent class is not present
+    expect {input.register}.to_not raise_error
+  end
+
+  context "when interrupting the plugin" do
+
+    it_behaves_like "an interruptible input plugin" do
+      let(:config) { { "command" => "uptime", "interval" => 0 } }
+    end
+
+    it_behaves_like "an interruptible input plugin" do
+      let(:config) { { "command" => "uptime", "interval" => 100 } }
+    end
+
+  end
+
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,3 @@
+# encoding: utf-8
+require "logstash/devutils/rspec/spec_helper"
+require "logstash/inputs/exec"


### PR DESCRIPTION
Implements `stop` to return from `run` according to https://github.com/elastic/logstash/issues/3210

Depends on https://github.com/elastic/logstash-devutils/pull/32 and https://github.com/elastic/logstash/pull/3895
