### PR TITLE
add 'schedule' option to allow cron scheduling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.2.0
+  - Add 'schedule' option to schedule the command to run, using a cron expression
+
 ## 3.1.5
   - Update gemspec summary
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -28,6 +28,21 @@ Notes:
 * The `message` field of this event will be the entire stdout of the command.
 
 
+Example:
+
+[source,ruby]
+----------------------------------
+input {
+  exec {
+    command => "ls"
+    interval => 30
+  }
+}
+----------------------------------
+
+This will execute `ls` command every 30 seconds.
+
+
 [id="plugins-{type}s-{plugin}-options"]
 ==== Exec Input Configuration Options
 
@@ -37,7 +52,8 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 |=======================================================================
 |Setting |Input type|Required
 | <<plugins-{type}s-{plugin}-command>> |<<string,string>>|Yes
-| <<plugins-{type}s-{plugin}-interval>> |<<number,number>>|Yes
+| <<plugins-{type}s-{plugin}-interval>> |<<number,number>>|No
+| <<plugins-{type}s-{plugin}-schedule>> |<<string,string>>|No
 |=======================================================================
 
 Also see <<plugins-{type}s-{plugin}-common-options>> for a list of options supported by all
@@ -57,12 +73,35 @@ Command to run. For example, `uptime`
 [id="plugins-{type}s-{plugin}-interval"]
 ===== `interval` 
 
-  * This is a required setting.
-  * Value type is <<number,number>>
+  * Value type is <<string,string>>
   * There is no default value for this setting.
 
 Interval to run the command. Value is in seconds.
 
+Either `interval` or `schedule` option must be defined.
+
+[id="plugins-{type}s-{plugin}-schedule"]
+===== `schedule` 
+
+  * Value type is <<number,number>>
+  * There is no default value for this setting.
+
+Schedule of when to periodically run command.
+
+This scheduling syntax is powered by https://github.com/jmettraux/rufus-scheduler[rufus-scheduler].
+The syntax is cron-like with some extensions specific to Rufus (e.g. timezone support).
+
+Examples:
+
+|==========================================================
+| `* 5 * 1-3 *`               | will execute every minute of 5am every day of January through March.
+| `0 * * * *`                 | will execute on the 0th minute of every hour every day.
+| `0 6 * * * America/Chicago` | will execute at 6:00am (UTC/GMT -5) every day.
+|==========================================================
+
+Further documentation describing this syntax can be found https://github.com/jmettraux/rufus-scheduler#parsing-cronlines-and-time-strings[here].
+
+Either `interval` or `schedule` option must be defined.
 
 
 [id="plugins-{type}s-{plugin}-common-options"]

--- a/lib/logstash/inputs/exec.rb
+++ b/lib/logstash/inputs/exec.rb
@@ -3,6 +3,7 @@ require "logstash/inputs/base"
 require "logstash/namespace"
 require "socket" # for Socket.gethostname
 require "stud/interval"
+require "rufus/scheduler"
 
 # Periodically run a shell command and capture the whole output as an event.
 #
@@ -17,22 +18,41 @@ class LogStash::Inputs::Exec < LogStash::Inputs::Base
 
   default :codec, "plain"
 
-  # Command to run. For example, `uptime`
+  # Command to run. For example : `uptime`
   config :command, :validate => :string, :required => true
 
   # Interval to run the command. Value is in seconds.
-  config :interval, :validate => :number, :required => true
+  # Either `interval` or `schedule` option must be defined.
+  config :interval, :validate => :number
+
+  # Schedule of when to periodically run command, in Cron format
+  # For example: "* * * * *" (execute command every minute, on the minute)
+  # Either `interval` or `schedule` option must be defined.
+  config :schedule, :validate => :string
 
   def register
-    @logger.info("Registering Exec Input", :type => @type, :command => @command, :interval => @interval)
+    @logger.info("Registering Exec Input", :type => @type, :command => @command, :interval => @interval, :schedule => @schedule)
     @hostname = Socket.gethostname
     @io       = nil
+    
+    if (@interval.nil? && @schedule.nil?) || (@interval && @schedule)
+      raise LogStash::ConfigurationError, "jdbc input: either 'interval' or 'schedule' option must be defined."
+    end
   end # def register
 
   def run(queue)
-    while !stop?
-      inner_run(queue)
-    end # loop
+    if @schedule
+          @scheduler = Rufus::Scheduler.new(:max_work_threads => 1)
+          @scheduler.cron @schedule do
+            inner_run(queue)
+          end
+          @scheduler.join
+    else
+      while !stop?
+        duration = inner_run(queue)
+        wait_until_end_of_interval(duration)
+      end # loop
+    end
   end # def run
 
   def inner_run(queue)
@@ -42,16 +62,22 @@ class LogStash::Inputs::Exec < LogStash::Inputs::Base
 
     @logger.debug? && @logger.debug("Command completed", :command => @command, :duration => duration)
 
-    wait_until_end_of_interval(duration)
+    return duration
   end
 
   def stop
+    close_io()
+    @scheduler.shutdown(:wait) if @scheduler
+  end
+
+  private
+
+  # Close @io
+  def close_io
     return if @io.nil? || @io.closed?
     @io.close
     @io = nil
   end
-
-  private
 
   # Wait until the end of the interval
   # @param [Integer] the duration of the last command executed
@@ -87,7 +113,7 @@ class LogStash::Inputs::Exec < LogStash::Inputs::Base
       @logger.error("Exception while running command",
         :command => command, :e => e, :backtrace => e.backtrace)
     ensure
-      stop
+      close_io()
     end
   end
 end # class LogStash::Inputs::Exec

--- a/lib/logstash/inputs/exec.rb
+++ b/lib/logstash/inputs/exec.rb
@@ -42,11 +42,11 @@ class LogStash::Inputs::Exec < LogStash::Inputs::Base
 
   def run(queue)
     if @schedule
-          @scheduler = Rufus::Scheduler.new(:max_work_threads => 1)
-          @scheduler.cron @schedule do
-            inner_run(queue)
-          end
-          @scheduler.join
+      @scheduler = Rufus::Scheduler.new(:max_work_threads => 1)
+      @scheduler.cron @schedule do
+        inner_run(queue)
+      end
+      @scheduler.join
     else
       while !stop?
         duration = inner_run(queue)

--- a/logstash-input-exec.gemspec
+++ b/logstash-input-exec.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-exec'
-  s.version         = '3.1.5'
+  s.version         = '3.2.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Captures the output of a shell command as an event"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"
@@ -23,7 +23,9 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
   s.add_runtime_dependency 'stud', '~> 0.0.22'
   s.add_runtime_dependency 'logstash-codec-plain'
+  s.add_runtime_dependency 'rufus-scheduler'
 
   s.add_development_dependency 'logstash-devutils'
+  s.add_development_dependency 'timecop'
 end
 

--- a/spec/inputs/exec_spec.rb
+++ b/spec/inputs/exec_spec.rb
@@ -1,13 +1,20 @@
 # encoding: utf-8
+require "timecop"
+require "time"
 require_relative "../spec_helper"
 
 describe LogStash::Inputs::Exec do
 
-  it "should register" do
-    input = LogStash::Plugin.lookup("input", "exec").new("command" => "ls", "interval" => 0)
-
-    # register will try to load jars and raise if it cannot find jars or if org.apache.log4j.spi.LoggingEvent class is not present
-    expect {input.register}.to_not raise_error
+  context "when register" do
+    it "should not raise error if config is valid" do
+      input = LogStash::Plugin.lookup("input", "exec").new("command" => "ls", "interval" => 0)
+      # register will try to load jars and raise if it cannot find jars or if org.apache.log4j.spi.LoggingEvent class is not present
+      expect {input.register}.to_not raise_error
+    end
+    it "should raise error if config is invalid" do
+      input = LogStash::Plugin.lookup("input", "exec").new("command" => "ls")
+      expect {input.register}.to raise_error
+    end
   end
 
   context "when operating normally" do
@@ -33,6 +40,30 @@ describe LogStash::Inputs::Exec do
 
       expect(queue.size).not_to be_zero
     end
+  end
+
+  context "when scheduling" do
+    let(:input) { LogStash::Plugin.lookup("input", "exec").new("command" => "ls", "schedule" => "* * * * * UTC") }
+    let(:queue) { [] }
+  
+    before do
+      input.register
+    end
+  
+    it "should properly schedule" do
+      Timecop.travel(Time.new(2000))
+      Timecop.scale(60)
+      runner = Thread.new do
+        input.run(queue)
+      end
+      sleep 3
+      input.stop
+      runner.kill
+      runner.join
+      expect(queue.size).to eq(2)
+      Timecop.return
+    end
+  
   end
 
   context "when interrupting the plugin" do


### PR DESCRIPTION
Like jdbc input plugin, it allows to schedule command execution using cron syntax.
This is particularly useful when you need to execute command each day at a specific hour.