### PR TITLE
Fix: behavior incompatiblity between (standalone) LS and LS in Docker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.5.0
+  - Fix: behavior incompatiblity between (standalone) LS and LS in Docker [#30](https://github.com/logstash-plugins/logstash-input-exec/pull/30)
+
 ## 3.4.0
   - Feat: adjust fields for ECS compatibility [#28](https://github.com/logstash-plugins/logstash-input-exec/pull/28)
   - Plugin will no longer override fields if they exist in the decoded payload.

--- a/lib/logstash/inputs/exec.rb
+++ b/lib/logstash/inputs/exec.rb
@@ -114,17 +114,17 @@ class LogStash::Inputs::Exec < LogStash::Inputs::Base
   end
 
   def close_out_and_in
-    do_close(@p_out)
+    close_io(@p_out)
     @p_out = nil
-    do_close(@p_in)
+    close_io(@p_in)
     @p_in = nil
   end
 
-  def do_close(io)
+  def close_io(io)
     return if io.nil? || io.closed?
     io.close
   rescue => e
-    @logger.debug("exception raised while closing io. ignoring..", :io => io, :exception => e.class, :message => e.message)
+    @logger.debug("ignoring exception raised while closing io", :io => io, :exception => e.class, :message => e.message)
   end
 
   # Wait until the end of the interval

--- a/lib/logstash/inputs/exec.rb
+++ b/lib/logstash/inputs/exec.rb
@@ -1,6 +1,7 @@
 # encoding: utf-8
 require "logstash/inputs/base"
 require "logstash/namespace"
+require "open3"
 require "socket" # for Socket.gethostname
 require "stud/interval"
 require "rufus/scheduler"
@@ -105,10 +106,10 @@ class LogStash::Inputs::Exec < LogStash::Inputs::Base
   private
 
   def run_command
-    @io = IO.popen(@command)
+    _, @io, status = Open3.popen2(@command)
     output = @io.read
-    @io.close # required in order to read $?
-    exit_status = $?.exitstatus
+    #@io.close # required in order to read $?
+    exit_status = status.value.exitstatus
     [output, exit_status]
   ensure
     close_io()

--- a/lib/logstash/inputs/exec.rb
+++ b/lib/logstash/inputs/exec.rb
@@ -123,6 +123,8 @@ class LogStash::Inputs::Exec < LogStash::Inputs::Base
   def do_close(io)
     return if io.nil? || io.closed?
     io.close
+  rescue => e
+    @logger.debug("exception raised while closing io. ignoring..", :io => io, :exception => e.class, :message => e.message)
   end
 
   # Wait until the end of the interval

--- a/logstash-input-exec.gemspec
+++ b/logstash-input-exec.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-exec'
-  s.version         = '3.4.0'
+  s.version         = '3.5.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Captures the output of a shell command as an event"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/inputs/exec_spec.rb
+++ b/spec/inputs/exec_spec.rb
@@ -46,6 +46,24 @@ describe LogStash::Inputs::Exec, :ecs_compatibility_support do
       end
     end
 
+    context "when command fails" do
+      let(:input) { described_class.new("command" => "invalid_command 1 2 3", "interval" => 0) }
+      let(:queue) { [] }
+
+      before :each do
+        input.register
+      end
+
+      it "does not enqueue an event (in a non-Docker env)" do
+        expect(input.logger).to receive(:error).and_call_original
+
+        input.execute(queue)
+
+        expect(queue.map(&:to_hash)).to be_empty
+      end
+    end # if ENV['CI'] != 'true'
+    # in Docker the behavior differs - missing command files are not raised
+
     context "when a command runs normally" do
       let(:command) { "/bin/sh -c 'sleep 1; /bin/echo -n two; exit 3'" }
       let(:input) { described_class.new("command" => command, "interval" => 0) }

--- a/spec/inputs/exec_spec.rb
+++ b/spec/inputs/exec_spec.rb
@@ -61,8 +61,7 @@ describe LogStash::Inputs::Exec, :ecs_compatibility_support do
 
         expect(queue.map(&:to_hash)).to be_empty
       end
-    end # if ENV['CI'] != 'true'
-    # in Docker the behavior differs - missing command files are not raised
+    end
 
     context "when a command runs normally" do
       let(:command) { "/bin/sh -c 'sleep 1; /bin/echo -n two; exit 3'" }


### PR DESCRIPTION
**Description of the problem including expected versus actual behavior (from #29)**:

> In the case a command to execute is missing, one expects `ENOENT` system error :
`Errno::ENOENT: No such file or directory - invalid_command for a missing command`,

> however the behavior is different in Docker - popen does not raise - we simply get a non-zero exit code:
`"message"=>"", "process"=>{"command_line"=>"invalid_command 1 2 3", "exit_code"=>127}`

---
PENDING suggestion from https://github.com/logstash-plugins/logstash-input-exec/pull/28#discussion_r747712250 :

> If there are two different behaviours, depending on which platform it is run, I would prefer we clearly specify both behaviours instead of specifying one of the behaviours and conditionally executing that spec.

> If possible, it could be helpful to _emulate_ the underlying change in behaviour and define our specs so that we can validate our effective behavour in CI regardless of which platform it is executed on (It would be hard to stub `IO::popen` because we rely on its side-effect of setting `$?`, but can we stub `run_command`?).

> So our specs output would look something like:

 - `when command fails`
   - `on a platform where IO.popen raises ENOENT`
     - `it does not enqueue an event`
   - `on a platform where IO.popen does not raise ENOENT (Docker)`
     - `it enqueues an event tagged with the error code`
---

**Ideally we would rather want the same behavior in Docker vs non-Docker LS ...**

By switching to `Open3`'s `popen` the behavior is now consistent between LS in Docker and standalone LS.

Previously, when a user would run Docker-ized LS using the exec input and points to a wrong/missing executable to run, the plugin would generates (error) events with a non-zero exit status (`127`), in standalone mode no events would have been generated.
