### PR TITLE
[Test] Add some extra wiggle room for scheduler to start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## unreleased
+  - Fix: Test failures due to insufficient time given for scheduler to start [#32](https://github.com/logstash-plugins/logstash-input-exec/pull/32) 
+
 ## 3.5.0
   - Fix: behavior incompatiblity between (standalone) LS and LS in Docker [#30](https://github.com/logstash-plugins/logstash-input-exec/pull/30)
 

--- a/spec/inputs/exec_spec.rb
+++ b/spec/inputs/exec_spec.rb
@@ -90,7 +90,7 @@ describe LogStash::Inputs::Exec, :ecs_compatibility_support do
         expect(elapsed_time).to be > 1 * 1_000_000
         expect(elapsed_time).to be < 3 * 1_000_000
       end if ecs_select.active_mode != :disabled
-      
+
       it "has output as expected" do
         expect(queue.pop.get('message')).to eq "two"
       end
@@ -116,7 +116,7 @@ describe LogStash::Inputs::Exec, :ecs_compatibility_support do
   end
 
   context "when scheduling" do
-    let(:input) { described_class.new("command" => "ls --help", "schedule" => "* * * * * UTC") }
+    let(:input) { described_class.new("command" => "ls", "schedule" => "4-5 * * * * UTC") }
     let(:queue) { [] }
 
     before do
@@ -129,7 +129,7 @@ describe LogStash::Inputs::Exec, :ecs_compatibility_support do
       runner = Thread.new do
         input.run(queue)
       end
-      sleep 3
+      sleep 6
       input.stop
       runner.kill
       runner.join

--- a/spec/inputs/exec_spec.rb
+++ b/spec/inputs/exec_spec.rb
@@ -116,25 +116,28 @@ describe LogStash::Inputs::Exec, :ecs_compatibility_support do
   end
 
   context "when scheduling" do
-    let(:input) { described_class.new("command" => "ls", "schedule" => "4-5 * * * * UTC") }
+    let(:input) { described_class.new("command" => "ls --help", "schedule" => "5-6 * * * * UTC") }
     let(:queue) { [] }
 
     before do
+      Timecop.travel(Time.new(2000))
+      Timecop.scale(60)
       input.register
     end
 
+    after do
+      Timecop.return
+    end
+
     it "should properly schedule" do
-      Timecop.travel(Time.new(2000))
-      Timecop.scale(60)
       runner = Thread.new do
         input.run(queue)
       end
-      sleep 6
+      sleep 10
       input.stop
       runner.kill
       runner.join
       expect(queue.size).to eq(2)
-      Timecop.return
     end
   end
 


### PR DESCRIPTION
Scheduler seems to take extra time to start up, so sleep for a little longer. Fix cron expression
to always run twice within sleep period.
